### PR TITLE
Handle 24-bit readout in a single frame

### DIFF
--- a/control/excalibur/fem_api_parameters.py
+++ b/control/excalibur/fem_api_parameters.py
@@ -1,6 +1,6 @@
 """fem_api_parameters.py - EXCALIBUR FEM API parameter definitions
 
-Automatically generated on: Mon Mar  5 13:29:32 2018 by generate_fem_api_parameters.py - do not edit manually!
+Automatically generated on: Tue Mar  6 15:59:56 2018 by generate_fem_api_parameters.py - do not edit manually!
 
 """
 
@@ -50,6 +50,7 @@ FEM_OP_FREEALLFRAMES = 4
 FEM_OP_LOADDACCONFIG = 5
 FEM_OP_FEINIT = 6
 FEM_OP_REBOOT = 7
+FEM_OP_RESET_UDP_COUNTER = 8
 FEM_OP_MPXIII_COLOURMODE = 1000
 FEM_OP_MPXIII_COUNTERDEPTH = 1001
 FEM_OP_MPXIII_EXTERNALTRIGGER = 1002

--- a/control/excalibur/parameter.py
+++ b/control/excalibur/parameter.py
@@ -203,3 +203,4 @@ class ExcaliburFrontEndCommandMap(OrderedDict):
         self['load_pixelconfig'] = (FEM_OP_LOADPIXELCONFIG, 'pixel config load', FEM_RTN_INTERNALERROR)
         self['load_dacconfig'] = (FEM_OP_LOADDACCONFIG, 'DAC config load', FEM_RTN_INTERNALERROR)
         self['fem_reboot'] = (FEM_OP_REBOOT, 'FEM reboot', FEM_RTN_INTERNALERROR)
+        self['reset_udp_counter'] = (FEM_OP_RESET_UDP_COUNTER, 'reset udp counter', FEM_RTN_INTERNALERROR)

--- a/control/fem_api_extension/api/include/femApi.h
+++ b/control/fem_api_extension/api/include/femApi.h
@@ -161,6 +161,7 @@ extern "C"
 #define FEM_OP_LOADDACCONFIG 5
 #define FEM_OP_FEINIT 6
 #define FEM_OP_REBOOT 7
+#define FEM_OP_RESET_UDP_COUNTER 8
 
 /* Medipix III global registers */
 #define FEM_OP_MPXIII_COLOURMODE 1000

--- a/control/fem_api_extension/api/src/ExcaliburFemClient.cpp
+++ b/control/fem_api_extension/api/src/ExcaliburFemClient.cpp
@@ -349,6 +349,11 @@ void ExcaliburFemClient::command(unsigned int aCommand)
       this->stopAcquisition();
       break;
 
+    case FEM_OP_RESET_UDP_COUNTER:
+      FEMLOG(mFemId, logDEBUG) << "Resetting UDP frame counter";
+      this->asicControlUdpCounterReset();
+      break;
+
     default:
       theCommand = aCommand;
       FemClient::command(theCommand);
@@ -479,11 +484,13 @@ void ExcaliburFemClient::startAcquisition(void)
   // Reset the 10GigE UDP counters on the FEM unless this is a matrix read of counter 0 in 24-bit
   // mode, in which case the frame counter should increment
 
-  if ((mMpx3OmrParams[0].counterDepth == counterDepth24) &&
-      (mOperationMode == excaliburOperationModeMatrixRead) &&
-      (mMpx3CounterSelect == mpx3Counter0))
+//  if ((mMpx3OmrParams[0].counterDepth == counterDepth24) &&
+//      (mOperationMode == excaliburOperationModeMatrixRead) &&
+//      (mMpx3CounterSelect == mpx3Counter0))
+  if (mMpx3OmrParams[0].counterDepth == counterDepth24)
   {
-    FEMLOG(mFemId, logDEBUG) << "Not resetting UDP frame counter in 24-bit C0 read acquisition";
+//    FEMLOG(mFemId, logDEBUG) << "Not resetting UDP frame counter in 24-bit C0 read acquisition";
+    FEMLOG(mFemId, logDEBUG) << "Not resetting UDP frame counter in 24-bit acquisition";
   }
   else
   {

--- a/control/fem_api_extension/api/src/femApi.cpp
+++ b/control/fem_api_extension/api/src/femApi.cpp
@@ -1188,6 +1188,10 @@ int femCmd(void* handle, int chipId, int id)
         (femHandle->client)->command(0);
         break;
 
+      case FEM_OP_RESET_UDP_COUNTER:
+        (femHandle->client)->command(id);
+        break;
+
       default:
         (femHandle->error).set() << "Illegal command id (" << id << ") specified";
         rc = FEM_RTN_UNKNOWNOPID;

--- a/data/common/include/ExcaliburDefinitions.h
+++ b/data/common/include/ExcaliburDefinitions.h
@@ -23,10 +23,12 @@ namespace Excalibur {
     static const size_t num_primary_packets[num_bit_depths] = { 4, 32, 65, 65 };
     static const size_t max_primary_packets = 65;
     static const size_t tail_packet_size[num_bit_depths] = { 768, 6152, 4296, 4296 };
+    static const size_t num_tail_packets = 1;
 
-    static const size_t num_tail_packets       = 1;
-    static const size_t num_subframes          = 2;
-    static const size_t max_num_fems           = 6;
+    static const size_t num_subframes[num_bit_depths] = {2, 2, 2, 4};
+    static const size_t max_num_subframes = 4;
+
+    static const size_t max_num_fems = 6;
 
     static const uint32_t start_of_frame_mask = 1 << 31;
     static const uint32_t end_of_frame_mask   = 1 << 30;
@@ -50,7 +52,7 @@ namespace Excalibur {
       uint32_t packets_received;
       uint8_t  sof_marker_count;
       uint8_t  eof_marker_count;
-      uint8_t  packet_state[num_subframes][max_primary_packets + num_tail_packets];
+      uint8_t  packet_state[max_num_subframes][max_primary_packets + num_tail_packets];
     } FemReceiveState;
 
     typedef struct
@@ -76,14 +78,14 @@ namespace Excalibur {
 
     inline const std::size_t max_frame_size(void)
     {
-      std::size_t max_frame_size = (subframe_size(bitDepth24) * num_subframes * max_num_fems)
-           + sizeof(FrameHeader);
+      std::size_t max_frame_size = sizeof(FrameHeader) +
+          (subframe_size(bitDepth24) * num_subframes[bitDepth24] * max_num_fems);
       return max_frame_size;
     }
 
     inline const std::size_t num_fem_frame_packets(const AsicCounterBitDepth bit_depth)
     {
-      std::size_t num_fem_frame_packets = num_subframes *
+      std::size_t num_fem_frame_packets = num_subframes[bit_depth] *
           (num_primary_packets[bit_depth] + num_tail_packets);
       return num_fem_frame_packets;
     }

--- a/data/frameProcessor/include/ExcaliburProcessPlugin.h
+++ b/data/frameProcessor/include/ExcaliburProcessPlugin.h
@@ -88,7 +88,8 @@ namespace FrameProcessor
     void reorder_1bit_stripe(unsigned int* in, unsigned char* out, bool stripe_is_even);
     void reorder_6bit_stripe(unsigned char* in, unsigned char* out, bool stripe_is_even);
     void reorder_12bit_stripe(unsigned short* in, unsigned short* out, bool stripe_is_even);
-    void build_24bit_image(unsigned short* inC0, unsigned short* inC1, unsigned int* out, int num_pixels);
+    void reorder_24bit_stripe(unsigned short* in_c0, unsigned short* in_c1, unsigned int* out,
+        bool stripe_is_even);
     std::size_t reordered_image_size(int asic_counter_depth_);
 
     /** Pointer to logger **/
@@ -101,8 +102,6 @@ namespace FrameProcessor
     int image_height_;
     /** Image pixel count **/
     int image_pixels_;
-    /** Counter used for construction of 24 bit frames **/
-    int frames_received_;
   };
 
   /**

--- a/data/frameReceiver/include/ExcaliburFrameDecoder.h
+++ b/data/frameReceiver/include/ExcaliburFrameDecoder.h
@@ -33,7 +33,6 @@ namespace FrameReceiver
   } ExcaliburDecoderFemMapEntry;
 
   typedef std::map<int, ExcaliburDecoderFemMapEntry> ExcaliburDecoderFemMap;
-  typedef std::map<int32_t, int32_t> FrameCounterMap;
 
   class ExcaliburFrameDecoder : public FrameDecoderUDP
   {
@@ -77,6 +76,7 @@ namespace FrameReceiver
     Excalibur::AsicCounterBitDepth parse_bit_depth(const std::string bit_depth_str);
 
     Excalibur::AsicCounterBitDepth asic_counter_bit_depth_;
+    std::size_t num_subframes_;
     ExcaliburDecoderFemMap fem_port_map_;
     boost::shared_ptr<void> current_packet_header_;
     boost::shared_ptr<void> dropped_frame_buffer_;
@@ -92,10 +92,6 @@ namespace FrameReceiver
     bool dropping_frame_data_;
     std::size_t packets_ignored_;
     bool has_subframe_trailer_;
-
-    FrameCounterMap shadow_frame_counter_map;
-    int32_t last_shadow_frame_number_;
-    int32_t current_shadow_frame_number_;
 
     static const std::string asic_bit_depth_str_[Excalibur::num_bit_depths];
 


### PR DESCRIPTION
This PR implements handling of 24-bit images in a single frame passed between FR and FP. Note there are also control-side changes made to handle the necessary control of the reset of the FEM UDP frame counter in 24-bit mode.