### PR TITLE
Fix memory leak in API wrapper methods.

### DIFF
--- a/control/fem_api_extension/fem_api_wrapper.c
+++ b/control/fem_api_extension/fem_api_wrapper.c
@@ -249,7 +249,10 @@ static PyObject* _get_int(PyObject* self, PyObject* args)
     }
     free(value_ptr);
 
-    return Py_BuildValue("iO", rc, values);
+    PyObject* result = Py_BuildValue("iO", rc, values);
+    Py_DECREF(values);
+
+    return result;
 }
 
 static PyObject* _set_int(PyObject* self, PyObject* args)
@@ -361,7 +364,10 @@ static PyObject* _get_short(PyObject* self, PyObject* args)
     }
     free(value_ptr);
 
-    return Py_BuildValue("iO", rc, values);
+    PyObject* result = Py_BuildValue("iO", rc, values);
+    Py_DECREF(values);
+
+    return result;
 }
 
 static PyObject* _set_short(PyObject* self, PyObject* args)
@@ -475,7 +481,10 @@ static PyObject* _get_float(PyObject* self, PyObject* args)
     }
     free(value_ptr);
 
-    return Py_BuildValue("iO", rc, values);
+    PyObject* result = Py_BuildValue("iO", rc, values);
+    Py_DECREF(values);
+
+    return result;
 }
 
 static PyObject* _set_float(PyObject* self, PyObject* args)


### PR DESCRIPTION
This fixes a per-call memory leak in the FEM API wrapper _get_XXX
functions, which build a list to return to the calling function.
Py_BuildValues() doesn't take ownership of the reference count, so it
is necessary to decouple that call from the return so that Py_DECREF
can be called on the list first.

Closes #16 