### PR TITLE
Changed port default from string to array

### DIFF
--- a/data/tools/python/excalibur_frame_producer.py
+++ b/data/tools/python/excalibur_frame_producer.py
@@ -82,7 +82,7 @@ class ExcaliburFrameProducerDefaults(object):
     def __init__(self):
 
         self.ip_addr = 'localhost'
-        self.port_list = '61649'
+        self.port_list = [61649]
         self.num_frames = 0
         self.tx_interval = 0
         self.drop_frac = 0


### PR DESCRIPTION
It seems the `CvsAction` class is not run when parsing the `--port` argument if the argument is not used, meaning the default value doesn't get split and convert into a list. I have changed this so the default value is already a list.