### PR TITLE
Fix test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ addons:
 install:
 - cd control
 - python setup.py --stub-only install
-- pip install --install-option='--stub-only' -e .[test]
 - pip install coveralls
 script:
-- python setup.py --stub-only nosetests
+- python setup.py --stub-only test
 - coverage report -m
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 python:
 - 2.7
-- 3.5
+- 3.6
 addons:
   apt:
     packages:

--- a/control/.coveragerc
+++ b/control/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *_version*

--- a/control/README.md
+++ b/control/README.md
@@ -1,11 +1,10 @@
-# odin-excalibur
-ODIN adapter plugin for the EXCALIBUR detector control system
+# ODIN EXCALIBUR
+ODIN control adapter plugin for the EXCALIBUR detector control system
 
 
-[![Build Status](https://travis-ci.org/stfc-aeg/odin-excalibur.svg)](https://travis-ci.org/stfc-aeg/odin-excalibur)
-[![Coverage Status](https://coveralls.io/repos/github/stfc-aeg/odin-excalibur/badge.svg?branch=master)](https://coveralls.io/github/stfc-aeg/odin-excalibur?branch=master)
-[![Stories in Ready](https://badge.waffle.io/stfc-aeg/odin-excalibur.png?label=ready&title=Ready)](https://waffle.io/stfc-aeg/odin-excalibur)
-[![Stories in In Progress](https://badge.waffle.io/stfc-aeg/odin-excalibur.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/stfc-aeg/odin-excalibur)
-[![Code Health](https://landscape.io/github/stfc-aeg/odin-excalibur/master/landscape.svg?style=flat)](https://landscape.io/github/stfc-aeg/odin-excalibur/master)
-[![Code Climate](https://codeclimate.com/github/stfc-aeg/odin-excalibur/badges/gpa.svg)](https://codeclimate.com/github/stfc-aeg/odin-excalibur)
-[![Test Coverage](https://codeclimate.com/github/stfc-aeg/odin-excalibur/badges/coverage.svg)](https://codeclimate.com/github/stfc-aeg/odin-excalibur/coverage)
+[![Build Status](https://travis-ci.org/dls-controls/excalibur-detector.svg?branch=master)](https://travis-ci.org/dls-controls/excalibur-detector)
+[![Coverage Status](https://coveralls.io/repos/github/dls-controls/excalibur-detector/badge.svg?branch=master)](https://coveralls.io/github/dls-controls/excalibur-detector?branch=master)
+[[![Waffle.io - Columns and their card count](https://badge.waffle.io/dls-controls/excalibur-detector.svg?columns=all)](https://waffle.io/dls-controls/excalibur-detector)
+![Code Health](https://landscape.io/github/dls-controls/excalibur-detector/master/landscape.svg?style=plastic)](https://landscape.io/github/dls-controls/excalibur-detector/master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/maintainability)](https://codeclimate.com/github/dls-controls/excalibur-detector/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/test_coverage)](https://codeclimate.com/github/dls-controls/excalibur-detector/test_coverage)

--- a/control/README.md
+++ b/control/README.md
@@ -4,7 +4,7 @@ ODIN control adapter plugin for the EXCALIBUR detector control system
 
 [![Build Status](https://travis-ci.org/dls-controls/excalibur-detector.svg?branch=master)](https://travis-ci.org/dls-controls/excalibur-detector)
 [![Coverage Status](https://coveralls.io/repos/github/dls-controls/excalibur-detector/badge.svg?branch=master)](https://coveralls.io/github/dls-controls/excalibur-detector?branch=master)
-[[![Waffle.io - Columns and their card count](https://badge.waffle.io/dls-controls/excalibur-detector.svg?columns=all)](https://waffle.io/dls-controls/excalibur-detector)
-![Code Health](https://landscape.io/github/dls-controls/excalibur-detector/master/landscape.svg?style=plastic)](https://landscape.io/github/dls-controls/excalibur-detector/master)
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/dls-controls/excalibur-detector.svg?columns=all)](https://waffle.io/dls-controls/excalibur-detector)
+[![Code Health](https://landscape.io/github/dls-controls/excalibur-detector/master/landscape.svg?style=plastic)](https://landscape.io/github/dls-controls/excalibur-detector/master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/maintainability)](https://codeclimate.com/github/dls-controls/excalibur-detector/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/test_coverage)](https://codeclimate.com/github/dls-controls/excalibur-detector/test_coverage)

--- a/control/excalibur/client/__init__.py
+++ b/control/excalibur/client/__init__.py
@@ -1,2 +1,2 @@
-from client import *
-from config_parser import *
+from .client import *
+from .config_parser import *

--- a/control/excalibur/client/config_parser.py
+++ b/control/excalibur/client/config_parser.py
@@ -5,7 +5,11 @@ Created on Apr 3 2017
 '''
 
 from collections import OrderedDict
-import ConfigParser
+try:                # pragma: no cover
+    import configparser
+except ImportError: # pragma: no cover
+    import ConfigParser as configparser
+    
 import logging
 import os
 import re
@@ -61,7 +65,7 @@ class ExcaliburDacConfigIniParser(object):
             'TPBufferOut': 'TPBuffOut',
         }
         
-        parser = ConfigParser.SafeConfigParser()
+        parser = configparser.SafeConfigParser()
         
         try:
             with open(config) as fp:

--- a/control/excalibur/parameter.py
+++ b/control/excalibur/parameter.py
@@ -7,7 +7,6 @@ Created on Mar 21, 2017
 from collections import OrderedDict
 
 from .fem_api_parameters import *
-from fem_api_parameters import FEM_OP_DAC_SCAN_STEPS_COMPLETE
 
 FEM_RTN_INTERNALERROR = -1
 CHIPS_PER_FEM = FEM_CHIPS_PER_STRIPE_X

--- a/control/excalibur/testing/test_adapter.py
+++ b/control/excalibur/testing/test_adapter.py
@@ -15,11 +15,13 @@ else:                         # pragma: no cover
 
 from excalibur.adapter import ExcaliburAdapter
 from excalibur.detector import ExcaliburDetectorError
+from excalibur.fem import ExcaliburFem
 
 class ExcaliburAdapterFixture(object):
 
     @classmethod
     def setup_class(cls, **adapter_params):
+        ExcaliburFem.use_stub_api = True
         cls.adapter = ExcaliburAdapter(**adapter_params)
         cls.path = 'status/fem'
         cls.request = Mock()

--- a/control/excalibur/testing/test_fem.py
+++ b/control/excalibur/testing/test_fem.py
@@ -117,9 +117,10 @@ class TestExcaliburFem:
 
         chip_id = 0
         param_id = 1001
+        offset = 0
         value = 1234
 
-        rc = self.the_fem.set_int(chip_id, param_id, value)
+        rc = self.the_fem.set_int(chip_id, param_id, offset, value)
 
         assert_equal(rc, FEM_RTN_OK)
 
@@ -128,9 +129,10 @@ class TestExcaliburFem:
         chip_id = 0
         param_id = 1001
         param_len = 10
+        offset = 0
         values = list(range(param_id, param_id + param_len))
 
-        rc = self.the_fem.set_int(chip_id, param_id, values)
+        rc = self.the_fem.set_int(chip_id, param_id, offset, values)
 
         assert_equal(rc, FEM_RTN_OK)
 
@@ -138,10 +140,11 @@ class TestExcaliburFem:
 
         chip_id = 0
         param_id = 10001
+        offset = 0
         values = [3.14]*10
 
         with assert_raises(ExcaliburFemError) as cm:
-            rc = self.the_fem.set_int(chip_id, param_id, values)
+            rc = self.the_fem.set_int(chip_id, param_id, offset, values)
         assert_equal(cm.exception.value, 'set_int: non-integer value specified')
 
     def test_legal_set_and_get_int(self):
@@ -149,9 +152,10 @@ class TestExcaliburFem:
         chip_id = 0
         param_id = 10002
         param_len = 100
+        offset = 0
         values_in = [random.randint(0, 1000000) for x in range(param_len)]
 
-        rc = self.the_fem.set_int(chip_id, param_id, values_in)
+        rc = self.the_fem.set_int(chip_id, param_id, offset, values_in)
         assert_equal(rc, FEM_RTN_OK)
 
         (rc, values_out) = self.the_fem.get_int(chip_id, param_id, param_len)
@@ -162,9 +166,10 @@ class TestExcaliburFem:
         
         chip_id = 0
         param_id = 1000
+        offset = 0
         values = [u"these", u"are", u"strings"]
         
-        rc = self.the_fem.set_string(chip_id, param_id, values)
+        rc = self.the_fem.set_string(chip_id, param_id, offset, values)
         assert_equal(rc, FEM_RTN_OK)
         
     def test_legal_cmd(self):

--- a/control/excalibur/testing/test_plugin.py
+++ b/control/excalibur/testing/test_plugin.py
@@ -10,13 +10,14 @@ import requests
 import json
 
 from odin.testing.utils import OdinTestServer
-
+from excalibur.fem import ExcaliburFem
 
 class TestExcaliburPlugin(OdinTestServer):
 
     @classmethod
     def setup_class(cls):
 
+        ExcaliburFem.use_stub_api = True
         cls.json_request_headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json'

--- a/control/setup.py
+++ b/control/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages, Extension
+from setuptools.command.test import test as TestCommand
 from distutils.command.build_ext import build_ext
 from distutils.command.clean import clean
 from distutils import log
@@ -11,6 +12,7 @@ import sys
 import subprocess
 import shlex
 
+# Extract the stub-only argument from the command line if present
 stub_only = False
 if '--stub-only' in sys.argv:
     stub_only = True
@@ -53,11 +55,18 @@ if not stub_only:
     )
 
     fem_ext_modules.append(fem_api)
+
   
 class ExcaliburBuildExt(build_ext):
+    """
+    Class to build the EXCALIBUR external API library module.
+    """
     
     def run(self):
-
+        """
+        Run the build command
+        """
+        
         # Precompile the API library if necessary        
         if not stub_only:
             if (self.precompile_api_library(fem_api)):
@@ -71,6 +80,9 @@ class ExcaliburBuildExt(build_ext):
         build_ext.run(self)
         
     def precompile_api_library(self, fem_api_ext):
+        """
+        Precompile the external FEM API library.
+        """
         
         log.info("Pre-compiling FEM API library")
 
@@ -115,6 +127,10 @@ class ExcaliburBuildExt(build_ext):
         return api_library_precompiled
         
     def makedir(self, path):
+        """
+        Make a directory at a specified path.
+        """
+        
         try:
             os.makedirs(path)
         except OSError:
@@ -122,7 +138,10 @@ class ExcaliburBuildExt(build_ext):
                 raise
             
     def build_make_cmd(self, flags=''):
-
+        """
+        Construct the make command used to build the API library.
+        """
+        
         make_cmd = 'make {} OBJ_DIR={} LIB_DIR={}'.format(
             flags, self.build_temp_obj_path, self.build_temp_lib_path
             )
@@ -130,13 +149,22 @@ class ExcaliburBuildExt(build_ext):
             make_cmd = make_cmd + ' BOOST_ROOT={}'.format(self.boost_root)
         
         return make_cmd
+
         
 class ExcaliburClean(clean):
+    """
+    Class to clean up the external API library build.
+    """
     
     def run(self):
-
+        """
+        Run the clean command.
+        """
+        
         target_path = 'excalibur'
-        ext_targets = [os.path.join(target_path, lib_name) for lib_name in ['fem_api.so', 'fem_api_stub.so']]
+        ext_targets = [os.path.join(target_path, lib_name) for lib_name in [
+            'fem_api.so', 'fem_api_stub.so'
+        ]]
         
         for ext_target in ext_targets:
             if os.path.exists(ext_target):
@@ -145,27 +173,72 @@ class ExcaliburClean(clean):
                                    
         clean.run(self)        
 
+
+class ExcaliburTest(TestCommand):
+    """
+    Class to test the package using nose correctly.
+    
+    Based on description at http://bit.ly/2IRKDE6
+    """
+    
+    def finalize_options(self):
+        """
+        Finalize command options.
+        """
+        
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        """
+        Run the test suite using nose.
+        """
+        import nose
+        nose.run_exit(argv=['nosetests'])
+
+# Build the command class for setup, merging in versioneer, build, clean and test commands
 merged_cmdclass = versioneer.get_cmdclass()
 merged_cmdclass.update({
     'build_ext': ExcaliburBuildExt,
     'clean': ExcaliburClean,
+    'test': ExcaliburTest,
     })
+
+# Define the required odin-control package version
+required_odin_version='0.3.1'
+
+# Define installation requirements based on odin version 
+install_requires = [
+    'odin=={:s}'.format(required_odin_version)
+]
+
+# Define installation requirements based on odin version 
+dependency_links = [
+    'https://github.com/odin-detector/odin-control/zipball/{0}#egg=odin-{0}'.format(
+        required_odin_version
+    )
+]
+
+tests_require = [
+    'nose', 
+    'coverage', 
+    'mock'
+]
 
 setup(
     name='excalibur',
     version=versioneer.get_version(),
     cmdclass=merged_cmdclass,
-    description='EXCALIBUR detector plugin for ODIN framework',
-    url='https://github.com/stfc-aeg/odin-excalibur',
+    description='EXCALIBUR detector plugins for ODIN control and data frameworks',
+    url='https://github.com/dls-controls/excalibur-detector',
     author='Tim Nicholls',
     author_email='tim.nicholls@stfc.ac.uk',
     ext_modules=fem_ext_modules,
     packages=find_packages(),
-    install_requires=['odin==0.2'],
-    dependency_links=['https://github.com/odin-detector/odin-control/zipball/0.2#egg=odin-0.2'],
-    extras_require={
-      'test': ['nose', 'coverage', 'mock'],  
-    },
+    install_requires=install_requires,
+    dependency_links=dependency_links,
+    tests_require=tests_require,  
     entry_points={
         'console_scripts': [
             'excalibur_test_app  = excalibur.client.test_app:main',


### PR DESCRIPTION
This PR implements fixes to allow the CI tests to pass on both python 2 and 3 for the EXCALIBUR odin-control adapter. This includes pinning the odin package version to tag 0.3.1 , where the primary change is to not install tornado version 5. 