### PR TITLE
Fix undefined reference to debug_level

### DIFF
--- a/data/frameProcessor/test/ExcaliburFrameProcessorTest.cpp
+++ b/data/frameProcessor/test/ExcaliburFrameProcessorTest.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 
 #include "ExcaliburProcessPlugin.h"
+#include "DebugLevelLogger.h"
+
+IMPLEMENT_DEBUG_LEVEL;
 
 class ExcaliburProcessPluginTestFixture
 {


### PR DESCRIPTION
Any application linking OdinData should implement debug levels.

This is the way suggested by this [change](https://github.com/odin-detector/odin-data/commit/c3fd903f69582ed673d628b91b5a770c79a5e074): 

However, there could be a better approach (as this implies repeating the same many times)
