### PR TITLE
Fix debug level implementation to match updated odin-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/data/frameProcessor/test/ExcaliburFrameProcessorTest.cpp
+++ b/data/frameProcessor/test/ExcaliburFrameProcessorTest.cpp
@@ -8,8 +8,6 @@
 #include "ExcaliburProcessPlugin.h"
 #include "DebugLevelLogger.h"
 
-IMPLEMENT_DEBUG_LEVEL;
-
 class ExcaliburProcessPluginTestFixture
 {
 public:

--- a/data/frameReceiver/src/ExcaliburFrameDecoder.cpp
+++ b/data/frameReceiver/src/ExcaliburFrameDecoder.cpp
@@ -622,7 +622,7 @@ void ExcaliburFrameDecoder::monitor_buffers(void)
   }
   frames_timedout_ += frames_timedout;
 
-  LOG4CXX_DEBUG_LEVEL(3, logger_,  get_num_mapped_buffers() << " frame buffers in use, "
+  LOG4CXX_DEBUG_LEVEL(4, logger_,  get_num_mapped_buffers() << " frame buffers in use, "
       << get_num_empty_buffers() << " empty buffers available, "
       << frames_timedout_ << " incomplete frames timed out, "
       << packets_lost_ << " packets lost"


### PR DESCRIPTION
Matches recent odin-data PR [#127](https://github.com/odin-detector/odin-data/pull/127). Explicit IMPLEMENT_DEBUG_LEVEL no longer required.