### PR TITLE
Allow test app and control client to be used from other scripts

### DIFF
--- a/control/excalibur/client/client.py
+++ b/control/excalibur/client/client.py
@@ -145,7 +145,7 @@ class ExcaliburParameter(OrderedDict):
      
 class ExcaliburClient(object):
         
-    def __init__(self, address='localhost', port=8888, log_level=logging.INFO):
+    def __init__(self, address='localhost', port=8888, logger=None, log_level=logging.INFO):
     
         self.url = 'http://{}:{}/api/0.1/excalibur/'.format(address, port)
         
@@ -156,7 +156,11 @@ class ExcaliburClient(object):
         
         self.request_headers = {'Content-Type': 'application/json'}
         
-        self.logger = logging.getLogger('ExcaliburClient')
+        if logger is None:
+            self.logger = logging.getLogger('ExcaliburClient')
+        else:
+            self.logger = logger
+            
         self.logger.setLevel(log_level)
         logging.getLogger('requests').setLevel(logging.WARNING)
         logging.getLogger('urllib3').setLevel(logging.WARNING)


### PR DESCRIPTION
This PR allows the standalone EXCALIBUR test application and its associated client class to be integrated into other control and monitoring scripts.

N.B. This functionality was used in the past to integrate the test app acquisition loop into an external monitoring script looking for packet loss associated with FEM resets causing link deadtime in the 10G deep buffer switch.