### PR TITLE
Fast Start

### DIFF
--- a/control/excalibur/hl_detector.py
+++ b/control/excalibur/hl_detector.py
@@ -567,13 +567,13 @@ class HLExcaliburDetector(ExcaliburDetector):
 
     def set_operation_mode(self, value):
         self._operation_mode = value
-    
+
     def get_lfsr_bypass(self):
         return self._lfsr_bypass
 
     def set_lfsr_bypass(self, value):
         self._lfsr_bypass = value
-    
+
     def get_read_write_mode(self):
         return self._read_write_mode
 
@@ -610,7 +610,7 @@ class HLExcaliburDetector(ExcaliburDetector):
     def set_csm_spm_mode(self, value):
         self._csm_spm_mode = value
         self._calibration_required = True
-    
+
     def get_colour_mode(self):
         return self._colour_mode
 
@@ -1067,7 +1067,7 @@ class HLExcaliburDetector(ExcaliburDetector):
 
     def get_chip_ids(self, fem_id):
         # Return either the default chip IDs or reversed chip IDs depending on the FEM
-        # ID.  TODO: 
+        # ID.  TODO:
         chip_ids = ExcaliburDefinitions.FEM_DEFAULT_CHIP_IDS
         if fem_id & 1 != 1:
             chip_ids = reversed(chip_ids)
@@ -1220,7 +1220,7 @@ class HLExcaliburDetector(ExcaliburDetector):
 
         with self._comms_lock:
             self.hl_write_params(pixel_params)
-        
+
             time.sleep(1.0)
 
             # Send the command to load the pixel configuration
@@ -1507,7 +1507,7 @@ class HLExcaliburDetector(ExcaliburDetector):
                             # Here we have detected a possible loss of connection
                             logging.error("Connection to hardware lost in power_card_read method")
                             self.connection_lost()
-        
+
         with self._param_lock:
             # Check for the current HV enabled state
             hv_enabled = 0
@@ -2032,7 +2032,7 @@ class HLExcaliburDetector(ExcaliburDetector):
         else:
             response_status = -1
             logging.error("No EFUSE ID root directory supplied")
-        
+
         logging.debug("EFUSE: %s", efuse_dict)
         return response_status, efuse_dict
 

--- a/control/excalibur/hl_detector.py
+++ b/control/excalibur/hl_detector.py
@@ -136,6 +136,7 @@ class HLExcaliburDetector(ExcaliburDetector):
         ]
 
     STR_STATUS = 'status'
+    STR_STATUS_POLL_ACTIVE = 'poll_active'
     STR_STATUS_SENSOR = 'sensor'
     STR_STATUS_SENSOR_WIDTH = 'width'
     STR_STATUS_SENSOR_HEIGHT = 'height'
@@ -328,6 +329,9 @@ class HLExcaliburDetector(ExcaliburDetector):
                     # Meta data here
                 }),
                 self.STR_STATUS_STATE: (self.get_state, {
+                    # Meta data here
+                }),
+                self.STR_STATUS_POLL_ACTIVE: (lambda: self._poll_active, {
                     # Meta data here
                 }),
                 self.STR_STATUS_FEM_STATE: (self.get_fem_state, {
@@ -1235,6 +1239,10 @@ class HLExcaliburDetector(ExcaliburDetector):
         self._poll_active = False
         self._poll_timeout = datetime.now()
 
+    def activate_polling(self):
+        logging.info("Activating polling now")
+        self._poll_active = True
+
     def status_loop(self):
         # Status loop has two polling rates, fast and slow
         # Fast poll is currently set to 0.2 s
@@ -1340,6 +1348,8 @@ class HLExcaliburDetector(ExcaliburDetector):
                 response = {'value': 1}
             elif path == 'command/pause_polling':
                 response = {'value': 1}
+            elif path == 'command/continue_polling':
+                response = {'value': 1}
             else:
                 try:
                     logging.debug("Searching for '%s': %s", path, self._tree_status.get(path, True))
@@ -1362,6 +1372,8 @@ class HLExcaliburDetector(ExcaliburDetector):
                 self.do_acquisition()
             elif path == 'command/pause_polling':
                 self.deactivate_polling()
+            elif path == 'command/continue_polling':
+                self.activate_polling()
             elif path == 'command/stop_acquisition':
                 # Starting an acquisition!
                 logging.debug('Abort acquisition has been called')


### PR DESCRIPTION
Add the option to pause and continue polling of slow parameters temporarily. This enables software step scans of single point acquisitions to be carried out without a delay in between each step for a parameter to be polled.