### PR TITLE
More fixes from updating to python3 at DLS

### DIFF
--- a/cpp/data/test/integrationTest/config/excalibur-fr.json
+++ b/cpp/data/test/integrationTest/config/excalibur-fr.json
@@ -3,11 +3,12 @@
     "decoder_type": "Excalibur",
     "decoder_path": "${CMAKE_INSTALL_PREFIX}/lib",
     "rx_ports": "61649",
-    "max_buffer_mem": 840000000,
+    "max_buffer_mem": 500000000,
     "decoder_config": {
       "enable_packet_logging": false,
       "frame_timeout_ms": 1000,
       "udp_packets_per_frame": 132
-    }
+    },
+    "frames": 10
   }
 ]

--- a/cpp/data/test/integrationTest/config/excalibur.json
+++ b/cpp/data/test/integrationTest/config/excalibur.json
@@ -34,12 +34,10 @@
         "packet-gap": 10
     },
     "receiver": {
-        "json_file": "${CMAKE_INSTALL_PREFIX}/test_config/excalibur-fr.json",
-        "m": "500000000",
-        "frames": 10
+        "config": "${CMAKE_INSTALL_PREFIX}/test_config/excalibur-fr.json"
     },
     "processor": {
-        "json_file": "${CMAKE_INSTALL_PREFIX}/test_config/excalibur-fp.json"
+        "config": "${CMAKE_INSTALL_PREFIX}/test_config/excalibur-fp.json"
     },
     "test": {
         "json": "${CMAKE_INSTALL_PREFIX}/test_config/test.json"

--- a/python/src/excalibur_detector/control/detector.py
+++ b/python/src/excalibur_detector/control/detector.py
@@ -529,7 +529,7 @@ class ExcaliburDetector(object):
 
     def write_fe_param(self, params):
 
-        logging.debug("In write_fe_param with params {:50.50} thread id {}".format(params, threading.current_thread().ident))
+        logging.debug("In write_fe_param with params {} thread id {}".format(params, threading.current_thread().ident))
 
         self.command_succeeded = True
         self.fe_param_write = []

--- a/python/src/excalibur_detector/control/detector.py
+++ b/python/src/excalibur_detector/control/detector.py
@@ -596,7 +596,6 @@ class ExcaliburDetector(object):
                 fem_idx,
                 params_by_fem[fem_idx],
             )
-            self._write_fe_param(fem_idx, params_by_fem[fem_idx])
 
         logging.debug("write_fe_param returning")
 

--- a/python/src/excalibur_detector/control/hl_detector.py
+++ b/python/src/excalibur_detector/control/hl_detector.py
@@ -205,7 +205,7 @@ class HLExcaliburDetector(ExcaliburDetector):
 
         self._startup_time = datetime.now()
         self._username = getpass.getuser()
-        self._fems = range(1, len(fem_connections)+1)
+        self._fems = list(range(1, len(fem_connections)+1))
         logging.debug("Fem conection IDs: %s", self._fems)
 
         self._default_status = []


### PR DESCRIPTION
Additional _write_fe_param call was introduced in #46 when updating to run in executor. The integration test fix is due to updates to odin-data. The other two issues just weren't found until running against a real detetector.