### PR TITLE
Chip status

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -21,8 +21,8 @@ package_dir =
     =src
 
 install_requires =
-    odin-control==1.4.0+dls1
-    odin-data==1.9.0+dls3
+    odin-control @ git+https://git@github.com/odin-detector/odin-control.git@1.5.0
+    odin-data @ git+https://git@github.com/odin-detector/odin-data.git@1.9.0
     configparser
     enum34
     requests  # For excalibur_test_app

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -21,7 +21,8 @@ package_dir =
     =src
 
 install_requires =
-    odin-control @ git+https://git@github.com/odin-detector/odin-control.git@1.3.0
+    odin-control==1.4.0+dls1
+    odin-data==1.9.0+dls3
     configparser
     enum34
     requests  # For excalibur_test_app

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -22,7 +22,6 @@ package_dir =
 
 install_requires =
     odin-control @ git+https://git@github.com/odin-detector/odin-control.git@1.5.0
-    odin-data @ git+https://git@github.com/odin-detector/odin-data.git@1.9.0
     configparser
     enum34
     requests  # For excalibur_test_app

--- a/python/src/excalibur_detector/control/definitions.py
+++ b/python/src/excalibur_detector/control/definitions.py
@@ -14,6 +14,12 @@ class ExcaliburDefinitions(object):
 
     FEM_DEFAULT_CHIP_IDS = [1, 2, 3, 4, 5, 6, 7, 8]
 
+    FEM_DAC_TARGET_VOLTAGES = {'gnd': 0.65, 'fbk': 0.9, 'cas': 0.85}
+    FEM_DAC_VOLTAGE_THRESHOLD = 0.005
+
+    # From page 23 Medipix III manual v19
+    FEM_DAC_SENSE_CODES = {'gnd': 20, 'fbk': 22, 'cas' : 23}
+
     FEM_PIXELS_PER_CHIP = X_PIXELS_PER_CHIP * Y_PIXELS_PER_CHIP
 
     FEM_TRIGMODE_INTERNAL = 0

--- a/python/src/excalibur_detector/control/definitions.py
+++ b/python/src/excalibur_detector/control/definitions.py
@@ -15,7 +15,7 @@ class ExcaliburDefinitions(object):
     FEM_DEFAULT_CHIP_IDS = [1, 2, 3, 4, 5, 6, 7, 8]
 
     FEM_DAC_TARGET_VOLTAGES = {'gnd': 0.65, 'fbk': 0.9, 'cas': 0.85}
-    FEM_DAC_VOLTAGE_THRESHOLD = 0.005
+    FEM_DAC_VOLTAGE_THRESHOLD = 0.01
 
     # From page 23 Medipix III manual v19
     FEM_DAC_SENSE_CODES = {'gnd': 20, 'fbk': 22, 'cas' : 23}

--- a/python/src/excalibur_detector/control/hl_detector.py
+++ b/python/src/excalibur_detector/control/hl_detector.py
@@ -105,6 +105,7 @@ class HLExcaliburDetector(ExcaliburDetector):
                         ]
 
     EFUSE_PARAMS = ['efuse_match']
+    EFUSE_PARAMS += ['efuse_c{}_match'.format(i) for i in range(len(ExcaliburDefinitions.FEM_DEFAULT_CHIP_IDS))]
     EFUSE_PARAMS += ['efuseid_c{}'.format(i) for i in range(len(ExcaliburDefinitions.FEM_DEFAULT_CHIP_IDS))]
     EFUSE_PARAMS += ['chipid_c{}'.format(i) for i in range(len(ExcaliburDefinitions.FEM_DEFAULT_CHIP_IDS))]
     EFUSE_PARAMS += ['efuseid_rbv_c{}'.format(i) for i in range(len(ExcaliburDefinitions.FEM_DEFAULT_CHIP_IDS))]
@@ -2057,6 +2058,7 @@ class HLExcaliburDetector(ExcaliburDetector):
         response_status = 0
         efuse_dict = {'efuse_match': []}
         for chip_i, chip in enumerate(ExcaliburDefinitions.FEM_DEFAULT_CHIP_IDS):
+            efuse_dict['efuse_c{}_match'.format(chip_i)] = []
             efuse_dict['efuseid_rbv_c{}'.format(chip_i)] = []
             efuse_dict['chipid_rbv_c{}'.format(chip_i)] = []
             efuse_dict['efuseid_c{}'.format(chip_i)] = []
@@ -2093,6 +2095,7 @@ class HLExcaliburDetector(ExcaliburDetector):
                                     efuse_dict['chipid_c{}'.format(chip_i)].append(self.decode_efuseid(calib_id))
                                     efuse_dict['efuseid_rbv_c{}'.format(chip_i)].append(hex(readback_id))
                                     efuse_dict['chipid_rbv_c{}'.format(chip_i)].append(self.decode_efuseid(readback_id))
+                                    efuse_dict['efuse_c{}_match'.format(chip_i)].append(calib_id==readback_id)
                                     if calib_id != readback_id:
                                         self.set_error('Fem {} Chip {} EFuseId mismatch'.format(fem, chip_i))
                                         id_match = 0

--- a/python/src/excalibur_detector/control/hl_detector.py
+++ b/python/src/excalibur_detector/control/hl_detector.py
@@ -2067,30 +2067,12 @@ class HLExcaliburDetector(ExcaliburDetector):
                             fem = 1
                             for efuse in status['efuseid']:
                                 id_match = 1
-                                efuse_dict['efuseid_c0'].append(efuse[0])
-                                if recorded_efuses[fem][1] != efuse[0]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c1'].append(efuse[1])
-                                if recorded_efuses[fem][2] != efuse[1]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c2'].append(efuse[2])
-                                if recorded_efuses[fem][3] != efuse[2]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c3'].append(efuse[3])
-                                if recorded_efuses[fem][4] != efuse[3]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c4'].append(efuse[4])
-                                if recorded_efuses[fem][5] != efuse[4]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c5'].append(efuse[5])
-                                if recorded_efuses[fem][6] != efuse[5]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c6'].append(efuse[6])
-                                if recorded_efuses[fem][7] != efuse[6]:
-                                    id_match = 0
-                                efuse_dict['efuseid_c7'].append(efuse[7])
-                                if recorded_efuses[fem][8] != efuse[7]:
-                                    id_match = 0
+                                for chip_i in range(len(ExcaliburDefinitions.X_CHIPS_PER_FEM)):
+                                    efuse_dict['efuseid_c{}'.format(chip_i)].append(efuse[chip_i])
+                                    if recorded_efuses[fem][chip_i+1] != efuse[chip_i]:
+                                        self.set_error('Fem {} Chip {} EFuseId mismatch')
+                                        id_match = 0
+                                        
                                 efuse_dict['efuse_match'].append(id_match)
                                 fem += 1
                         break

--- a/python/src/excalibur_detector/control/hl_detector.py
+++ b/python/src/excalibur_detector/control/hl_detector.py
@@ -2095,7 +2095,7 @@ class HLExcaliburDetector(ExcaliburDetector):
                                     efuse_dict['chipid_c{}'.format(chip_i)].append(self.decode_efuseid(calib_id))
                                     efuse_dict['efuseid_rbv_c{}'.format(chip_i)].append(hex(readback_id))
                                     efuse_dict['chipid_rbv_c{}'.format(chip_i)].append(self.decode_efuseid(readback_id))
-                                    efuse_dict['efuse_c{}_match'.format(chip_i)].append(calib_id==readback_id)
+                                    efuse_dict['efuse_c{}_match'.format(chip_i)].append(int(calib_id==readback_id))
                                     if calib_id != readback_id:
                                         self.set_error('Fem {} Chip {} EFuseId mismatch'.format(fem, chip_i))
                                         id_match = 0


### PR DESCRIPTION
Adds two features:

- Readback of primary FEM DAC voltages (CAS, GND and FBK) and performs a check against expected values and tolerance.
- Readback of FEM EFuse IDs and performs a check against the calibrated IDs. Also "decodes" the IDs to retrieve their physical position on each chip. 

If either of the above checks fail, a new toggle setting determines if the detector goes into an error state (default behaviour) or just displays a new type of warning message.