### PR TITLE
Adjust test FR config to conform with odin-data changes

### DIFF
--- a/cpp/data/test/integrationTest/config/excalibur-fr.json
+++ b/cpp/data/test/integrationTest/config/excalibur-fr.json
@@ -1,5 +1,7 @@
 [
   {
+    "frame_ready_endpoint": "tcp://127.0.0.1:5001",
+    "frame_release_endpoint": "tcp://127.0.0.1:5002",
     "decoder_type": "Excalibur",
     "decoder_path": "${CMAKE_INSTALL_PREFIX}/lib",
     "rx_ports": "61649",


### PR DESCRIPTION
Specifically, the frame ready and release endpoints must be defined explicitly in the FR config