### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/dls-controls/excalibur-detector.svg?branch=master)](https://travis-ci.org/dls-controls/excalibur-detector)
-[![Stories in Ready](https://badge.waffle.io/dls-controls/excalibur-detector.svg?label=ready&title=Ready)](http://waffle.io/dls-controls/excalibur-detector)
-[![Stories in In Progress](https://badge.waffle.io/dls-controls/excalibur-detector.svg?label=In%20Progress&title=In%20Progress)](http://waffle.io/dls-controls/excalibur-detector)
-[![Code Climate](https://codeclimate.com/github/dls-controls/excalibur-detector/badges/gpa.svg)](https://codeclimate.com/github/dls-controls/excalibur-detector)
+[![Build Status](https://travis-ci.org/DiamondLightSource/excalibur-detector.svg?branch=master)](https://travis-ci.org/DiamondLightSource/excalibur-detector)
+[![Stories in Ready](https://badge.waffle.io/DiamondLightSource/excalibur-detector.svg?label=ready&title=Ready)](http://waffle.io/DiamondLightSource/excalibur-detector)
+[![Stories in In Progress](https://badge.waffle.io/DiamondLightSource/excalibur-detector.svg?label=In%20Progress&title=In%20Progress)](http://waffle.io/DiamondLightSource/excalibur-detector)
+[![Code Climate](https://codeclimate.com/github/DiamondLightSource/excalibur-detector/badges/gpa.svg)](https://codeclimate.com/github/DiamondLightSource/excalibur-detector)
 
 # excalibur-detector
 Excalibur Detector control and DAQ software applications

--- a/python/README.md
+++ b/python/README.md
@@ -2,9 +2,9 @@
 ODIN control adapter plugin for the EXCALIBUR detector control system
 
 
-[![Build Status](https://travis-ci.org/dls-controls/excalibur-detector.svg?branch=master)](https://travis-ci.org/dls-controls/excalibur-detector)
-[![Coverage Status](https://coveralls.io/repos/github/dls-controls/excalibur-detector/badge.svg?branch=master)](https://coveralls.io/github/dls-controls/excalibur-detector?branch=master)
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/dls-controls/excalibur-detector.svg?columns=all)](https://waffle.io/dls-controls/excalibur-detector)
-[![Code Health](https://landscape.io/github/dls-controls/excalibur-detector/master/landscape.svg?style=plastic)](https://landscape.io/github/dls-controls/excalibur-detector/master)
-[![Maintainability](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/maintainability)](https://codeclimate.com/github/dls-controls/excalibur-detector/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/test_coverage)](https://codeclimate.com/github/dls-controls/excalibur-detector/test_coverage)
+[![Build Status](https://travis-ci.org/DiamondLightSource/excalibur-detector.svg?branch=master)](https://travis-ci.org/DiamondLightSource/excalibur-detector)
+[![Coverage Status](https://coveralls.io/repos/github/DiamondLightSource/excalibur-detector/badge.svg?branch=master)](https://coveralls.io/github/DiamondLightSource/excalibur-detector?branch=master)
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/DiamondLightSource/excalibur-detector.svg?columns=all)](https://waffle.io/DiamondLightSource/excalibur-detector)
+[![Code Health](https://landscape.io/github/DiamondLightSource/excalibur-detector/master/landscape.svg?style=plastic)](https://landscape.io/github/DiamondLightSource/excalibur-detector/master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/maintainability)](https://codeclimate.com/github/DiamondLightSource/excalibur-detector/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/962bd509787942efb2ea/test_coverage)](https://codeclimate.com/github/DiamondLightSource/excalibur-detector/test_coverage)

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = excalibur-detector
 description = EXCALIBUR detector plugins for ODIN control
-url = https://github.com/dls-controls/excalibur-detector/python
+url = https://github.com/DiamondLightSource/excalibur-detector/python
 author = Tim Nicholls
 author_email = tim.nicholls@stfc.ac.uk
 license = Apache License 2.0


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/excalibur-detector` using https://gitlab.diamond.ac.uk/github/github-scripts